### PR TITLE
feat: Improve `text_overflow` docs (#1064)

### DIFF
--- a/crates/elements/src/_docs/attributes/text_overflow.md
+++ b/crates/elements/src/_docs/attributes/text_overflow.md
@@ -2,10 +2,11 @@ Determines how text is treated when it exceeds its [`max_lines`](#max_lines) cou
 
 Accepted values:
 
-- `clip` (default)
-- `ellipsis`
+- `clip` (default): Simply cut the text.
+- `ellipsis`: Show `…`.
+- `[custom-value]: Show a custom value.
 
-### Example
+### Ellipsis example
 
 ```rust, no_run
 # use freya::prelude::*;
@@ -19,3 +20,19 @@ fn app() -> Element {
     )
 }
 ```
+
+### Custom value example
+
+```rust, no_run
+# use freya::prelude::*;
+fn app() -> Element {
+    rsx!(
+        label {
+            max_lines: "3",
+            text_overflow: ".......too long.",
+            "Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong text"
+        }
+    )
+}
+```
+

--- a/crates/state/src/values/font.rs
+++ b/crates/state/src/values/font.rs
@@ -94,7 +94,7 @@ impl TextOverflow {
     pub fn get_ellipsis(&self) -> Option<&str> {
         match self {
             Self::Clip => None,
-            Self::Ellipsis => Some("..."),
+            Self::Ellipsis => Some("…"),
             Self::Custom(custom) => Some(custom),
         }
     }


### PR DESCRIPTION
* feat: Improve `text_overflow` docs

* use non-html syntax